### PR TITLE
_tileShouldBeLoaded logic now discards unused tiles.

### DIFF
--- a/L.TileLayer.Zoomify.js
+++ b/L.TileLayer.Zoomify.js
@@ -5,7 +5,8 @@
 L.TileLayer.Zoomify = L.TileLayer.extend({
 	options: {
 		continuousWorld: true,
-		tolerance: 0.8
+		tolerance: 0.8,
+		unloadInvisibleTiles: true
 	},
 
 	initialize: function (url, options) {
@@ -64,8 +65,23 @@ L.TileLayer.Zoomify = L.TileLayer.extend({
 
 	_tileShouldBeLoaded: function (tilePoint) {
 		var gridSize = this._gridSize[this._map.getZoom()];
-		return (tilePoint.x >= 0 && tilePoint.x < gridSize.x && tilePoint.y >= 0 && tilePoint.y < gridSize.y);
+
+		// Is this a valid Zoomify tile?
+		if(tilePoint.x < 0 || tilePoint.y < 0 || tilePoint.x >= gridSize.x || tilePoint.y >= gridSize.y){
+			return false;
+		}
+
+		// Delegate to the parent function for regular tile visibility logic
+		// FIXME: Looks like this functionality is no longer in master and may
+		// disappear in the future.
+		if(L.TileLayer.prototype._tileShouldBeLoaded){
+			return L.TileLayer.prototype._tileShouldBeLoaded.call(this, tilePoint);
+		} else {
+			return true;
+		}
 	},
+
+
 
 	_addTile: function (tilePoint, container) {
 		var tilePos = this._getTilePos(tilePoint),


### PR DESCRIPTION
Once a Zoomify tile is loaded it sticks around forever, and on large Zoomify images this becomes was a massive performance issue. This PR aims to fix this by delegating to the parent _tileShouldBeLoaded function to add the extra visibility logic that the existing function doesn't have.

I've tested it on one of my Zoomify images and the example.html so I'm reasonably confident it works, but there may be edge cases it hasn't accounted for.

(Side note, it turns out the _tileShouldBeLoaded method no longer exists in the master Leaflet repo thus the check to see if it exists, so this plugin may not work in the next major release, but that's a separate issue.)
