### PR TITLE
Update code to Leaflet 1.0.0-b1

### DIFF
--- a/L.TileLayer.Zoomify.js
+++ b/L.TileLayer.Zoomify.js
@@ -1,114 +1,123 @@
 /*
  * L.TileLayer.Zoomify display Zoomify tiles with Leaflet
+ *
+ * Developed for Leaflet 1.0-dev
+ *
+ * Based on the Leaflet.Zoomify (https://github.com/turban/Leaflet.Zoomify) 
+ * from turban (https://github.com/turban)
+ * 
  */
-
+ 
 L.TileLayer.Zoomify = L.TileLayer.extend({
 	options: {
-		continuousWorld: true,
-		tolerance: 0.8
+		width: -1, //Must be set by user, max zoom image width
+		height: -1, //Must be set by user, max zoom image height
+		tileGroupPrefix: 'TileGroup',
+		tilesPerTileGroup: 256
 	},
 
 	initialize: function (url, options) {
-		options = L.setOptions(this, options);
+		var options = L.setOptions(this, options);
 		this._url = url;
 
+		//Replace with automatic loading from ImageProperties.xml
+		if(options.width < 0 || options.height < 0)
+		{
+			throw new Error("The user must set the Width and Height of the Zoomify image");
+		}
+		
     	var imageSize = L.point(options.width, options.height),
 	    	tileSize = options.tileSize;
 
+		//Build the zoom sizes of the pyramid and cache them in an array
     	this._imageSize = [imageSize];
     	this._gridSize = [this._getGridSize(imageSize)];
-
+		
+		//Register the image size in pixels and the grid size in # of tiles for each zoom level
+        var imageSize;
         while (parseInt(imageSize.x) > tileSize || parseInt(imageSize.y) > tileSize) {
-        	imageSize = imageSize.divideBy(2).floor();
+        	imageSize = imageSize.divideBy(2).ceil();
         	this._imageSize.push(imageSize);
         	this._gridSize.push(this._getGridSize(imageSize));
         }
 
+		//We built the cache from bottom to top, but leaflet uses a top to bottom index for the zoomlevel, 
+		// so reverse it for easy indexing by current zoomlevel
 		this._imageSize.reverse();
 		this._gridSize.reverse();
 
-        this.options.maxZoom = this._gridSize.length - 1;
+		//Register our max supported zoom level
+        options.maxNativeZoom = this._gridSize.length - 1;
+		
+		//Register our bounds for this zoomify layer based on the maximum zoom
+		var maxZoomGrid = this._gridSize[options.maxNativeZoom];
+		var southWest = map.unproject([0,maxZoomGrid.y*tileSize], options.maxNativeZoom);
+		var northEast = map.unproject([maxZoomGrid.x*tileSize,0], options.maxNativeZoom);
+		options.bounds = new L.LatLngBounds(southWest, northEast);		
 	},
 
-	onAdd: function (map) {
-		L.TileLayer.prototype.onAdd.call(this, map);
-
-		var mapSize = map.getSize(),
-			zoom = this._getBestFitZoom(mapSize),
-			imageSize = this._imageSize[zoom],
-			center = map.options.crs.pointToLatLng(L.point(imageSize.x / 2, imageSize.y / 2), zoom);
-
-		map.setView(center, zoom, true);
-	},
-
+	//Calculate the grid size for a given image size (based on tile size)
 	_getGridSize: function (imageSize) {
 		var tileSize = this.options.tileSize;
 		return L.point(Math.ceil(imageSize.x / tileSize), Math.ceil(imageSize.y / tileSize));
 	},
 
-	_getBestFitZoom: function (mapSize) {
-		var tolerance = this.options.tolerance,
-			zoom = this._imageSize.length - 1,
-			imageSize, zoom;
+	//Extend the add tile function to update our arbitrary sized border tiles
+	_addTile: function (coords, container) {
+		//Load the tile via the original leaflet code
+		L.TileLayer.prototype._addTile.call(this, coords, container);
 
-		while (zoom) {
-			imageSize = this._imageSize[zoom];
-			if (imageSize.x * tolerance < mapSize.x && imageSize.y * tolerance < mapSize.y) {
-				return zoom;
-			}			
-			zoom--;
-		}
-
-		return zoom;
-	},
-
-	_tileShouldBeLoaded: function (tilePoint) {
-		var gridSize = this._gridSize[this._map.getZoom()];
-		return (tilePoint.x >= 0 && tilePoint.x < gridSize.x && tilePoint.y >= 0 && tilePoint.y < gridSize.y);
-	},
-
-	_addTile: function (tilePoint, container) {
-		var tilePos = this._getTilePos(tilePoint),
-			tile = this._getTile(),
-			zoom = this._map.getZoom(),
-			imageSize = this._imageSize[zoom],
-			gridSize = this._gridSize[zoom],
-			tileSize = this.options.tileSize;
-
-		if (tilePoint.x === gridSize.x - 1) {
-			tile.style.width = imageSize.x - (tileSize * (gridSize.x - 1)) + 'px';
+		//Get out imagesize in pixels for this zoom level and our grid size
+		var imageSize = this._imageSize[this._getZoomForUrl()],
+			gridSize = this._gridSize[this._getZoomForUrl()];
+			
+		//The real tile size (default:256) and the display tile size (if zoom > maxNativeZoom)
+		var	realTileSize = L.GridLayer.prototype.getTileSize.call(this),
+			displayTileSize = L.TileLayer.prototype.getTileSize.call(this);
+		
+		//Get the current tile to adjust
+		var key = this._tileCoordsToKey(coords),
+			tile = this._tiles[key].el;
+		
+		//Calculate the required size of the border tiles
+		var scaleFactor = L.point(	(imageSize.x % realTileSize.x), 
+									(imageSize.y % realTileSize.y)).unscaleBy(realTileSize);
+		
+		//Update tile dimensions if we are on a border
+		if ((imageSize.x % realTileSize.x) > 0 && coords.x === gridSize.x - 1) {
+			tile.style.width = displayTileSize.scaleBy(scaleFactor).x + 'px';
 		} 
 
-		if (tilePoint.y === gridSize.y - 1) {
-			tile.style.height = imageSize.y - (tileSize * (gridSize.y - 1)) + 'px';			
+		if ((imageSize.y % realTileSize.y) > 0 && coords.y === gridSize.y - 1) {
+			tile.style.height = displayTileSize.scaleBy(scaleFactor).y + 'px';			
 		} 
-
-		L.DomUtil.setPosition(tile, tilePos, L.Browser.chrome || L.Browser.android23);
-
-		this._tiles[tilePoint.x + ':' + tilePoint.y] = tile;
-		this._loadTile(tile, tilePoint);
-
-		if (tile.parentNode !== this._tileContainer) {
-			container.appendChild(tile);
-		}
 	},
 
-	getTileUrl: function (tilePoint) {
-		return this._url + 'TileGroup' + this._getTileGroup(tilePoint) + '/' + this._map.getZoom() + '-' + tilePoint.x + '-' + tilePoint.y + '.jpg';
+	
+	//Construct the tile url, by inserting our tilegroup before we template the url
+	getTileUrl: function (coords) {
+		//Set our TileGroup variable, and then let the original tile templater do the work
+		this.options.g = this.options.tileGroupPrefix+this._getTileGroup(coords)
+		
+		//Call the original templater
+		return L.TileLayer.prototype.getTileUrl.call(this, coords);
 	},
 
-	_getTileGroup: function (tilePoint) {
-		var zoom = this._map.getZoom(),
+	//Calculates the TileGroup number, each group contains 256 tiles. The tiles are stored from topleft to bottomright
+	_getTileGroup: function (coords) {
+		var zoom = this._getZoomForUrl(),
 			num = 0,
 			gridSize;
 
-		for (z = 0; z < zoom; z++) {
+		//Get the total number of tiles from the lowest zoom level to our zoomlevel
+		for (var z = 0; z < zoom; z++) {
 			gridSize = this._gridSize[z];
 			num += gridSize.x * gridSize.y; 
 		}	
 
-		num += tilePoint.y * this._gridSize[zoom].x + tilePoint.x;
-      	return Math.floor(num / 256);;
+		//Add the remaining tiles from this zoom layer to the running total of tiles
+		num += coords.y * this._gridSize[zoom].x + coords.x;
+      	return Math.floor(num / this.options.tilesPerTileGroup);
 	}
 
 });

--- a/README.md
+++ b/README.md
@@ -1,6 +1,42 @@
 Leaflet.Zoomify
-===============
+==========
+##Description
+A tiny simple plugin for [Leaflet](http://leafletjs.com) to load Zoomify tiles from the TileGroup directories. It also corrects the arbritary boundary tiles that do not always have the standard square dimensions.
 
-Display Zoomify tiles with Leaflet.
+##Requirements
+- Leaflet 1.0.0-b1 (or later)
+- Zoomify tile source
 
-<a href="http://blog.thematicmapping.org/2013/06/showing-zoomify-images-with-leaflet.html">More information</a>
+##Example
+See the example.html file
+
+##Compatibility
+Extends the original Leaflet TileLayer, so everything that ```L.TileLayer``` supports, is supported by this plugin.
+
+##Usage
+Just include the ```L.TileLayer.Zoomify.js``` file in your page and create a l.tilelayer.zoomify:
+```js
+var layer = L.tileLayer.zoomify('http://thematicmapping.org/playground/zoomify/books/{g}/{z}-{x}-{y}.jpg', {
+			width: 5472,
+			height: 3648,
+			attribution: '&copy; Photo: Bjørn Sandvik'
+		}).addTo(map);
+```
+Example Zoomify image by [turban](https://github.com/turban) 
+
+##API
+#### L.tileLayer.zoomify(urlTemplate, options)
+Constructs a regular TileLayer that has overloaded some specific functions for tile loading.
+
+The urlTemplate will be a regular Leaflet [url template](http://leafletjs.com/reference.html#url-template), but also has the ```{g}``` variable available that contains the current TileGroup number. E.g. ```www.your.url/{g}/{z}-{x}-{y}.jpg``` converts to ```www.your.url/TileGroup0/1-0-0.jpg``` for the lowest zoom tile.
+
+The regular [L.TileLayer options](http://leafletjs.com/reference.html#tilelayer-options) are extended with the following:
+#####Required options
+- **width** - The width of the Zoomify image (max zoomed in), see ImageProperties.xml
+- **height** - The height of the Zoomify image (max zoomed in), see ImageProperties.xml (**required to set**)
+
+#####Optional
+- **tileGroupPrefix** - The prefix used for the tile subdirectories (*default:* TileGroup)
+- **tilesPerTileGroup** - The number of tiles per subdirectory (*default:* 256)
+
+The Zoomify layer exposes its size in ```layer.options.bounds```, and could be used for constraining movement or to set the viewport with ```map.fitBounds(layer.options.bounds)```.

--- a/example.html
+++ b/example.html
@@ -2,11 +2,8 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Leaflet Zoomify Demo</title>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.5.1/leaflet.css" />
-    <!--[if lte IE 8]>
-        <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.5.1/leaflet.ie.css" />
-    <![endif]-->
+    <title>Leaflet 1.0.0-b1 Zoomify Demo</title>
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet.css" />
     <style type="text/css">
         html, body, #photo {
             width: 100%;
@@ -19,19 +16,25 @@
 
 <body>
     <div id="photo"></div>
-    <script src="http://cdn.leafletjs.com/leaflet-0.5.1/leaflet.js"></script>
+    <script src="http://cdn.leafletjs.com/leaflet-1.0.0-b1/leaflet-src.js"></script>
     <script type="text/javascript" src="L.TileLayer.Zoomify.js"></script>  
-    <script type="text/javascript">
+    
+    <script type="application/javascript">
+		var map = L.map('photo', {
+        	maxZoom: 15, //Does not matter anymore, maxNativeZoom prevents loading of missing zoom levels
+	        minZoom: 0,
+   	     	crs: L.CRS.Simple //Set a flat projection, as we are projecting an image
+    	});
+    	
+    	//Loading the Zoomify tile layer, notice the URL
+    	var layer = L.tileLayer.zoomify('http://thematicmapping.org/playground/zoomify/books/{g}/{z}-{x}-{y}.jpg', {
+			width: 5472,
+			height: 3648,
+			attribution: '&copy; Photo: Bjørn Sandvik'
+		}).addTo(map);
 
-        var map = L.map('photo').setView(new L.LatLng(0,0), 0);
-
-        L.tileLayer.zoomify('http://thematicmapping.org/playground/zoomify/books/', { 
-            width: 5472, 
-            height: 3648,
-            tolerance: 0.8,
-            attribution: 'Photo: Bjørn Sandvik'
-        }).addTo(map);
-
+		//Setting the view to our layer bounds, set by our Zoomify plugin
+		map.fitBounds(layer.options.bounds);
     </script>
 </body>
 </html>


### PR DESCRIPTION
The current codebase is not compatible anymore with Leaflet 1.0.0, as many things have changed. I needed the Zoomify plugin for a project and updated the plugin.

I am happy to share my update of the code, if you like the changes I made.
- The url now uses the url-templater, injecting the TileGroup number as variable (`{g}`)
- The tile creation is now done by `L.GridLayer` and `L.TileLayer`, and only the size is changed if the tile is on a edge (often having arbitrary tile dimensions)
- The view is not set anymore, but the bounds are exposed in `layer.options.bounds`, and could be used with `map.fitBounds(layer.options.bounds)` to center and zoom the Zoomify layer in the viewport
- The Zoomify layer can be zoomed beyond available zoom levels by setting the options.maxNativeZoom option accordingly, making it possible for `L.TileLayer` to scale the tiles accordingly
